### PR TITLE
Fix Xdebug error in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,10 @@ language: php
 
 sudo: true
 
+env:
+  global:
+    - XDEBUG_MODE=coverage
+
 services:
   - docker
 


### PR DESCRIPTION
Run phpunit with XDEBUG_MODE=coverage 

Some constants are only available in certain modes in Xdebug 3. This is fixed in the latest Xdebug release but not yet available in the version used by Travis. Also, it won't hurt to run xdebug in coverage mode.

See: xdebug/xdebug#699